### PR TITLE
Add var.atlantis_repo_config to support --repo-config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,10 @@ locals {
       name  = "ATLANTIS_HIDE_PREV_PLAN_COMMENTS"
       value = var.atlantis_hide_prev_plan_comments
     },
+    {
+      name  = "ATLANTIS_REPO_CONFIG"
+      value = var.atlantis_repo_config
+    },
   ]
 
   # Secret access tokens

--- a/variables.tf
+++ b/variables.tf
@@ -439,6 +439,12 @@ variable "atlantis_hide_prev_plan_comments" {
   default     = "false"
 }
 
+variable "atlantis_repo_config" {
+  description = "Path to an atlantis repo config file, used to customize how Atlantis runs on each repo, via --repo-config"
+  type        = string
+  default     = ""
+}
+
 # Github
 variable "atlantis_github_user" {
   description = "GitHub username that is running the Atlantis command"


### PR DESCRIPTION
Default: not set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gozer/terraform-aws-atlantis/1)
<!-- Reviewable:end -->
